### PR TITLE
Do not show header stack when not necessary.

### DIFF
--- a/SheetViewController/Classes/SheetViewController/SheetContentView.swift
+++ b/SheetViewController/Classes/SheetViewController/SheetContentView.swift
@@ -66,6 +66,7 @@ public class SheetContentView: UIView, ContentView {
   
   //MARK: - Methods
   public func addHeaderView(_ view: UIView) {
+    headerStack?.isHidden = false
     headerStack?.addArrangedSubview(view)
   }
   
@@ -92,6 +93,7 @@ fileprivate extension SheetContentView {
     headerStack?.isLayoutMarginsRelativeArrangement = true
     headerStack?.spacing = configuration.innerContentSpacing.height
     headerStack?.axis = .vertical
+    headerStack?.isHidden = true
     
     let contentStack = UIStackView(frame: .zero)
     contentStack.axis = .vertical


### PR DESCRIPTION
### Problem
When alert is created without title and message, Sheet will show empty space on top.
### Code
```
let alert = SheetViewController.alert(
      with: nil,
      message: nil,
      alignmentType: .bottom,
      actionType: .inner)
```
### Result
![screenshot](https://user-images.githubusercontent.com/1449108/75538677-4b2acd80-5a19-11ea-8c2d-fc8cfa303aae.png)
### Solution
Make header view hidden until it's needed.